### PR TITLE
Add tooltips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/docs/classless.css
+++ b/docs/classless.css
@@ -67,8 +67,6 @@ ul, ol, dl, fieldset, pre, pre > code, caption {
 	display: block;
 	margin: 0.5rem 0rem 1rem;
 	width: 100%;
-	overflow-x: auto;
-	overflow-y: hidden;
 	text-align: left;
 }
 html { background-color: var(--cbg); }
@@ -445,11 +443,11 @@ abbr[data-title]:before {
 	background-color: var(--cmed);
 	color: #fff;
 	color: var(--font-p);
+  white-space: normal;
 
 	text-align:center;
 	display: none;
 }
-
 abbr[data-title]:hover:before, abbr[data-title]:active:before {
 	display: block;
 }

--- a/docs/classless.css
+++ b/docs/classless.css
@@ -402,38 +402,39 @@ button[disabled]{ color: var(--cdark); border-color: var(--cmed); }
 .p-1, .py-1, .pb-1 { padding-bottom: 1.0rem !important; }
 
 /* tooltips */
-*[data-tooltip-text] {
+abbr[data-title] {
 	position: relative;
 	cursor: pointer;
-	text-decoration:underline;
-	text-decoration-thickness: 2px;
-	text-decoration-style: dotted;
-	text-decoration-color: var(--font-p);
+
+  text-decoration:underline;
+  text-decoration-thickness: 2px;
+  text-decoration-style: dotted;
+  text-decoration-color: var(--font-p);
 }
-*[data-tooltip-pos="left"]:before {
+abbr[data-position="left"]:before {
 	top:50%;
 	transform:translateY(-50%);
 	left:100%;
 	margin-left:15px;
 }
-*[data-tooltip-pos="top"]:before {
+abbr[data-position="top"]:before {
 	left: 50%;
 	transform: translateY(-100%) translateX(-50%);
 	margin-top: -15px;
 }
-*[data-tooltip-pos="bottom"]:before {
+abbr[data-position="bottom"]:before {
 	left: 50%;
 	transform: translateY(100%) translateX(-50%);
 	margin-top: -15px;
 }
-*[data-tooltip-pos="right"]:before {
+abbr[data-position="right"]:before {
 	top:50%;
 	transform:translateY(-50%);
 	right: 100%;
 	margin-right:15px;
 }
-*[data-tooltip-text]:before {
-	content: attr(data-tooltip-text);
+abbr[data-title]:before {
+	content: attr(data-title);
 	z-index: 42;
 
 	position: absolute;
@@ -449,6 +450,6 @@ button[disabled]{ color: var(--cdark); border-color: var(--cmed); }
 	display: none;
 }
 
-*[data-tooltip-text]:hover:before {
+abbr[data-title]:hover:before, abbr[data-title]:active:before {
 	display: block;
 }

--- a/docs/classless.css
+++ b/docs/classless.css
@@ -67,6 +67,8 @@ ul, ol, dl, fieldset, pre, pre > code, caption {
 	display: block;
 	margin: 0.5rem 0rem 1rem;
 	width: 100%;
+	overflow-x: auto;
+	overflow-y: hidden;
 	text-align: left;
 }
 html { background-color: var(--cbg); }

--- a/docs/classless.css
+++ b/docs/classless.css
@@ -441,8 +441,8 @@ abbr[data-title]:before {
 	width:200px;
 	padding:10px;
 	background-color: var(--cmed);
-	color: #fff;
-	color: var(--font-p);
+	font: var(--font-p);
+  color: var(--cfg);
   white-space: normal;
 
 	text-align:center;

--- a/docs/classless.css
+++ b/docs/classless.css
@@ -400,3 +400,55 @@ button[disabled]{ color: var(--cdark); border-color: var(--cmed); }
 .p-1, .px-1, .pl-1 { padding-left:   1.0rem !important; }
 .p-1, .py-1, .pt-1 { padding-top:    1.0rem !important; }
 .p-1, .py-1, .pb-1 { padding-bottom: 1.0rem !important; }
+
+/* tooltips */
+*[data-tooltip-text] {
+	position: relative;
+	cursor: pointer;
+	text-decoration:underline;
+	text-decoration-thickness: 2px;
+	text-decoration-style: dotted;
+	text-decoration-color: var(--font-p);
+}
+*[data-tooltip-pos="left"]:before {
+	top:50%;
+	transform:translateY(-50%);
+	left:100%;
+	margin-left:15px;
+}
+*[data-tooltip-pos="top"]:before {
+	left: 50%;
+	transform: translateY(-100%) translateX(-50%);
+	margin-top: -15px;
+}
+*[data-tooltip-pos="bottom"]:before {
+	left: 50%;
+	transform: translateY(100%) translateX(-50%);
+	margin-top: -15px;
+}
+*[data-tooltip-pos="right"]:before {
+	top:50%;
+	transform:translateY(-50%);
+	right: 100%;
+	margin-right:15px;
+}
+*[data-tooltip-text]:before {
+	content: attr(data-tooltip-text);
+	z-index: 42;
+
+	position: absolute;
+	border-radius: .3rem;
+
+	width:200px;
+	padding:10px;
+	background-color: var(--cmed);
+	color: #fff;
+	color: var(--font-p);
+
+	text-align:center;
+	display: none;
+}
+
+*[data-tooltip-text]:hover:before {
+	display: block;
+}

--- a/docs/classless.css
+++ b/docs/classless.css
@@ -399,55 +399,18 @@ button[disabled]{ color: var(--cdark); border-color: var(--cmed); }
 .p-1, .py-1, .pt-1 { padding-top:    1.0rem !important; }
 .p-1, .py-1, .pb-1 { padding-bottom: 1.0rem !important; }
 
-/* tooltips */
-abbr[data-title] {
-	position: relative;
-	cursor: pointer;
-
-  text-decoration:underline;
-  text-decoration-thickness: 2px;
-  text-decoration-style: dotted;
-  text-decoration-color: var(--font-p);
-}
-abbr[data-position="left"]:before {
-	top:50%;
-	transform:translateY(-50%);
-	left:100%;
-	margin-left:15px;
-}
-abbr[data-position="top"]:before {
-	left: 50%;
-	transform: translateY(-100%) translateX(-50%);
-	margin-top: -15px;
-}
-abbr[data-position="bottom"]:before {
-	left: 50%;
-	transform: translateY(100%) translateX(-50%);
-	margin-top: -15px;
-}
-abbr[data-position="right"]:before {
-	top:50%;
-	transform:translateY(-50%);
-	right: 100%;
-	margin-right:15px;
-}
-abbr[data-title]:before {
-	content: attr(data-title);
-	z-index: 42;
-
-	position: absolute;
-	border-radius: .3rem;
-
-	width:200px;
-	padding:10px;
-	background-color: var(--cmed);
-	font: var(--font-p);
-  color: var(--cfg);
-  white-space: normal;
-
-	text-align:center;
-	display: none;
-}
-abbr[data-title]:hover:before, abbr[data-title]:active:before {
-	display: block;
+abbr[data-title] { position: relative; text-decoration: underline dotted; cursor: help; }
+@media (max-width:1024px) {
+	abbr[data-title]:hover::before,
+	abbr[data-title]:focus::before {
+		position: absolute;
+		bottom: 2em;
+		width: 10em;
+		padding: .5em .7em;
+		color: var(--cbg);
+		background-color: var(--cfg);
+		box-shadow: .1rem .1rem .4rem 0 var(--cfg);
+		content: attr(data-title);
+		white-space: normal;
+	}
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -369,10 +369,15 @@
     <h2>Tables</h2>
     <p>The basic HTML tables allow already quite complex layouts. As often seen in professional tables, we omit vertical lines and and only insert horizontal lines as visual separation.</p>
     <div class="row">
-      <div class="col">      
+      <div class="col">
         <table>
           <thead><tr>
-            <th>Head 1</th>  <th>Head 2</th>      
+            <th>
+              <abbr data-position="top" data-title="Tooltips work in table headers too!">
+                Head 1 with a tooltip
+              </abbr>
+            </th>
+            <th>Head 2</th>
           </tr></thead>
           <tbody>
             <tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -740,34 +740,38 @@
 
     <section id="card">
       <h2>Tooltips</h2>
-      <p>Any element can have a tooltip in one of the four directions.</p>
+      <p>
+        An <code>&lt;abbr&gt;</code> element can have a tooltip in one of the
+        four directions. On touch devices, the tooltip is shown when the user
+        touches and holds the element.
+      </p>
       <div class="row">
         <div class="col-3">
-          <span
-            data-tooltip-pos="left"
-            data-tooltip-text="A tooltip to the left.">Left</span>
+          <abbr
+            data-position="left"
+            data-title="A tooltip to the left.">Left</abbr>
         </div>
         <div class="col-3">
-          <span
-            data-tooltip-pos="top"
-            data-tooltip-text="A tooltip on the top">Top</span>
+          <abbr
+            data-position="top"
+            data-title="A tooltip on the top">Top</abbr>
         </div>
         <div class="col-3">
-          <span
-            data-tooltip-pos="bottom"
-            data-tooltip-text="A tooltip on the bottom">Bottom</span>
+          <abbr
+            data-position="bottom"
+            data-title="A tooltip on the bottom">Bottom</abbr>
         </div>
         <div class="col-3">
-          <span
-            data-tooltip-pos="right"
-            data-tooltip-text="A tooltip on the right">Right</span>
+          <abbr
+            data-position="right"
+            data-title="A tooltip on the right">Right</abbr>
         </div>
       </div>
-      <pre><code>&lt;span
-  data-tooltip-pos=&quot;right&quot;
-  data-tooltip-text=&quot;A tooltip on the right&quot;&gt;
+      <pre><code>&lt;abbr
+  data-position=&quot;right&quot;
+  data-title=&quot;A tooltip on the right&quot;&gt;
   Right
-&lt;/span&gt;<code></pre>
+&lt;/abbr&gt;<code></pre>
     </section>
 
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -738,6 +738,38 @@
     </div>
     </section>
 
+    <section id="card">
+      <h2>Tooltips</h2>
+      <p>Any element can have a tooltip in one of the four directions.</p>
+      <div class="row">
+        <div class="col-3">
+          <span
+            data-tooltip-pos="left"
+            data-tooltip-text="A tooltip to the left.">Left</span>
+        </div>
+        <div class="col-3">
+          <span
+            data-tooltip-pos="top"
+            data-tooltip-text="A tooltip on the top">Top</span>
+        </div>
+        <div class="col-3">
+          <span
+            data-tooltip-pos="bottom"
+            data-tooltip-text="A tooltip on the bottom">Bottom</span>
+        </div>
+        <div class="col-3">
+          <span
+            data-tooltip-pos="right"
+            data-tooltip-text="A tooltip on the right">Right</span>
+        </div>
+      </div>
+      <pre><code>&lt;span
+  data-tooltip-pos=&quot;right&quot;
+  data-tooltip-text=&quot;A tooltip on the right&quot;&gt;
+  Right
+&lt;/span&gt;<code></pre>
+    </section>
+
 
     </article>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -373,9 +373,7 @@
         <table>
           <thead><tr>
             <th>
-              <abbr data-title="Tooltips work in table headers too!">
-                Head 1 with a tooltip
-              </abbr>
+              Head 1
             </th>
             <th>Head 2</th>
           </tr></thead>

--- a/docs/index.html
+++ b/docs/index.html
@@ -373,7 +373,7 @@
         <table>
           <thead><tr>
             <th>
-              <abbr data-position="top" data-title="Tooltips work in table headers too!">
+              <abbr data-title="Tooltips work in table headers too!">
                 Head 1 with a tooltip
               </abbr>
             </th>
@@ -746,36 +746,12 @@
     <section id="card">
       <h2>Tooltips</h2>
       <p>
-        An <code>&lt;abbr&gt;</code> element can have a tooltip in one of the
-        four directions. On touch devices, the tooltip is shown when the user
-        touches and holds the element.
+        An <code>&lt;abbr&gt;</code> element can have a tooltip by defining
+        the <code>data-title</code> attribute.
       </p>
-      <div class="row">
-        <div class="col-3">
-          <abbr
-            data-position="left"
-            data-title="A tooltip to the left.">Left</abbr>
-        </div>
-        <div class="col-3">
-          <abbr
-            data-position="top"
-            data-title="A tooltip on the top">Top</abbr>
-        </div>
-        <div class="col-3">
-          <abbr
-            data-position="bottom"
-            data-title="A tooltip on the bottom">Bottom</abbr>
-        </div>
-        <div class="col-3">
-          <abbr
-            data-position="right"
-            data-title="A tooltip on the right">Right</abbr>
-        </div>
-      </div>
-      <pre><code>&lt;abbr
-  data-position=&quot;right&quot;
-  data-title=&quot;A tooltip on the right&quot;&gt;
-  Right
+      <abbr data-title="A tooltip that contains text.">A tooltip</abbr>
+      <pre><code>&lt;abbr data-title=&quot;A tooltip that contains text.&quot;&gt;
+  A tooltip
 &lt;/abbr&gt;<code></pre>
     </section>
 


### PR DESCRIPTION
- Fixes #8

FYI: Note, I had to remove `overflow-y: hidden` and `overflow-x` from your reset script to make the tooltips work in tables (see 8f1df42). I tried breaking out without removing those two lines, but I failed.