### PR TITLE
table isn't a display: block element

### DIFF
--- a/docs/classless.css
+++ b/docs/classless.css
@@ -41,6 +41,10 @@ ul, ol, dl, fieldset, pre, pre > code, caption {
 	overflow: auto hidden;
 	text-align: left;
 }
+
+table {
+	display: table;
+}
 video, summary, input, select { outline:none; }
 
 /* reset clickable things  (FF Bug: select:hover prevents usage) */


### PR DESCRIPTION
switches table back to display: table

Found this while debugging fullcalendar
on a site, which uses tables extensively
but broke with classless css.